### PR TITLE
fix hash comparison

### DIFF
--- a/e4WorkflowApp.php
+++ b/e4WorkflowApp.php
@@ -168,7 +168,7 @@ class e4WorkflowApp
 	public function exportConfig()
 	{
 		$content = json_encode($this->defaults);
-		if (md5($content) == $this->defaultsHash)
+		if (md5($content) === $this->defaultsHash)
 			return false;
 		file_put_contents($this->configPath.'config.json', $content);
 		return true;


### PR DESCRIPTION
You can't compare strings/hashes in PHP with just the equality operator (==), you need to check that the 2 strings/parts are identical (see http://php.net/manual/en/language.operators.comparison.php).
This problem is actually very widespread and some blogs/articles deal with it e.g. (just one randomly picked page that explains this problem) https://www.whitehatsec.com/blog/magic-hashes/